### PR TITLE
User's list of service shortened URLs

### DIFF
--- a/app/assets/stylesheets/1st_load_framework.css.scss
+++ b/app/assets/stylesheets/1st_load_framework.css.scss
@@ -11,7 +11,10 @@ body { padding-top: 70px; }
 .inner {
   padding: 30px;
 }
-
+.my_links{
+  padding-bottom: 50px;
+  margin-bottom:30px;
+}
 /* Tooltip */
 .test + .tooltip > .tooltip-inner {
     background-color: #3498db;

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,7 +1,8 @@
 class LinksController < ApplicationController
   include LinksHelper
-  
+
   before_action :set_link, only: [:show, :edit, :update, :destroy]
+  before_action :authenticate_user, except: [:create, :redirect_link]
 
   # GET /links
   # GET /links.json
@@ -27,13 +28,23 @@ class LinksController < ApplicationController
   # POST /links.json
   def create
     @link = Link.new(link_params)
+    @link.user_id = (current_user) ? session[:user_id] : 0
 
     respond_to do |format|
       if @link.save
-        format.html { redirect_to @link, notice: 'Link was successfully created.' }
-        format.json { render :show, status: :created, location: @link }
+        if current_user
+          format.html do
+            redirect_to dashboard_path, notice: "Link was successfully created."
+          end
+        else
+          format.html do
+            redirect_to root_path, notice: "Link was successfully created."
+          end
+          format.json { render :show, status: :created, location: @link }
+        end
       else
-        format.html { render :new }
+        flash[:error] = "Url field is empty, please enter information."
+        format.html { redirect_to :back }
         format.json { render json: @link.errors, status: :unprocessable_entity }
       end
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,7 @@
 class PagesController < ApplicationController
   before_action :set_auth
   before_action :authenticate_user, only: :dashboard
-  
+
   def index
     @link = Link.new
     @popular = Link.popular.limit(5) unless (Link.popular).nil?
@@ -11,6 +11,7 @@ class PagesController < ApplicationController
   def dashboard
     @link = Link.new
     @user = current_user
+    @user_links = @user.links
   end
 
   private

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -3,6 +3,7 @@ class Link < ActiveRecord::Base
   before_save :url_check
   has_many :clicks
   validates :url, presence: true
+  belongs_to :user, counter_cache: true
 
   scope :recent, lambda {
     order("links.created_at DESC")
@@ -20,7 +21,7 @@ class Link < ActiveRecord::Base
 
   def set_short_url
     return short_url if short_url.present?
-    
+
     try_short_url = SecureRandom.urlsafe_base64(4)
     while Link.where(:short_url => try_short_url).any?
       try_short_url = SecureRandom.urlsafe_base64(4)

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -11,9 +11,7 @@
       <%= link_to 'Home', root_path, class: 'navbar-brand' %>
     </div>
     <div class="collapse navbar-collapse">
-      <ul class="nav navbar-nav">
         <%= render 'layouts/navigation_links' %>
-      </ul>
     </div>
   </div>
 </nav>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -18,3 +18,36 @@
   </div>
 </div>
 <hr>
+<div class="col-sm-12  col-sm-offset-0 my_links" align ="center">
+  <h2 class="sub-header">My Links</h2>
+  <div class="table-responsive">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>Short Url</th>
+          <th>Clicks</th>
+          <th>Long Url</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @user_links.each do |link| %>
+          <tr>
+            <td><a href = <%= "
+              #{display_link(link.short_url)}"%>
+              target ="_blank"><%= display_link(link.short_url)%></a>
+            </td>
+            <td><span class="badge"><%= link.clicks_count %>&nbsp;
+              <%= link.clicks_count == 1 ? "click" : "clicks" %></span>
+            </td>
+            <td><%= link.url %></td>
+            <td><%= link_to 'Details', link %></td>
+            <td><%= link_to 'Edit', edit_link_path(link) %></td>
+            <td><%= link_to 'Destroy', link, method: :delete,
+                  data: { confirm: 'Are you sure?' } %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/db/migrate/20151216163002_add_user_to_link.rb
+++ b/db/migrate/20151216163002_add_user_to_link.rb
@@ -1,0 +1,5 @@
+class AddUserToLink < ActiveRecord::Migration
+  def change
+    add_reference :links, :user, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151216042847) do
+ActiveRecord::Schema.define(version: 20151216163002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,7 +30,10 @@ ActiveRecord::Schema.define(version: 20151216042847) do
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.integer  "clicks_count", default: 0
+    t.integer  "user_id"
   end
+
+  add_index "links", ["user_id"], name: "index_links_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "provider",                null: false
@@ -47,4 +50,5 @@ ActiveRecord::Schema.define(version: 20151216042847) do
   add_index "users", ["uid"], name: "index_users_on_uid", using: :btree
 
   add_foreign_key "clicks", "links"
+  add_foreign_key "links", "users"
 end


### PR DESCRIPTION
Why: So registered users can see a list of all their service shortened URLs on their page.

This change addresses the need by:
*Creating a migration to add user_id column t the Link model
*Retrieving the all links belonging to the user in PagesController#dashboard for display in the view
*Modifying the user dashboard to display the list of user's links

[Finishes #110112382]
