### PR TITLE
Service shortened URL details

### DIFF
--- a/app/assets/stylesheets/1st_load_framework.css.scss
+++ b/app/assets/stylesheets/1st_load_framework.css.scss
@@ -13,7 +13,7 @@ body { padding-top: 70px; }
 }
 .btm-space{
   padding-bottom: 50px;
-  margin-bottom:30px;
+  margin-bottom:50px;
 }
 /* Tooltip */
 .test + .tooltip > .tooltip-inner {

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,5 +1,6 @@
 class LinksController < ApplicationController
   include LinksHelper
+  include ClicksHelper  
 
   before_action :set_link, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user, except: [:create, :redirect_link]
@@ -13,6 +14,12 @@ class LinksController < ApplicationController
   # GET /links/1
   # GET /links/1.json
   def show
+    @link = Link.find(params[:id])
+    @num_of_days = (params[:num_of_days] || 15).to_i
+    @count_days_bar = Click.count_days_bar(params[:id], @num_of_days)
+    chart = Click.count_country_chart(params[:id], params[:map] || "world")
+    @count_country_map = chart[:map]
+    @count_country_bar = chart[:bar]
   end
 
   # GET /links/new
@@ -76,6 +83,10 @@ class LinksController < ApplicationController
 
   def redirect_link
     @link = Link.find_by(short_url: params[:path])
+    click = @link.clicks.new(ip: get_remote_ip)
+    click.country = get_remote_country
+    click.save
+    @link.save
     redirect_to @link.url
   end
 

--- a/app/helpers/clicks_helper.rb
+++ b/app/helpers/clicks_helper.rb
@@ -1,2 +1,9 @@
 module ClicksHelper
+  def get_remote_ip
+    request.remote_ip
+  end
+
+  def get_remote_country
+    request.location.country
+  end
 end

--- a/app/models/click.rb
+++ b/app/models/click.rb
@@ -1,3 +1,38 @@
 class Click < ActiveRecord::Base
   belongs_to :link, counter_cache: true
+  def self.count_days_bar(identifier,num_of_days)
+    clicks = count_by_date_with(identifier,num_of_days)
+    data, labels = [], []
+    clicks.each {|click| data << click[1]; labels << "#{click[0].day}/#{click[0].month}" }
+    "http://chart.apis.google.com/chart?chs=820x180&cht=bvs&chxt=x&chco=a4b3f4&chm=N,000000,0,-1,11&chxl=0:|#{labels.join('|')}&chds=0,#{data.sort.last+10}&chd=t:#{data.join(',')}"
+  end
+
+  def self.count_country_chart(identifier,map)
+    countries, count = [], []
+    count_by_country_with(identifier).each {|click| countries << click.country; count << click.count }
+    chart = {}
+    chart[:map] = "http://chart.apis.google.com/chart?chs=440x220&cht=t&chtm=#{map}&chco=FFFFFF,a4b3f4,0000FF&chld=#{countries.join('')}&chd=t:#{count.join(',')}"
+    chart[:bar] = "http://chart.apis.google.com/chart?chs=320x240&cht=bhs&chco=a4b3f4&chm=N,000000,0,-1,11&chbh=a&chd=t:#{count.join(',')}&chxt=x,y&chxl=1:|#{countries.reverse.join('|')}"
+    return chart
+  end
+
+  def self.count_by_date_with(identifier,num_of_days)
+    start_date = Date.today - num_of_days.day
+    end_date = Date.today + 1
+    clicks = Click.select("date(created_at) as date, count(*) as count")
+                  .where("link_id = #{identifier} AND created_at >= to_timestamp(#{start_date}) AND created_at < to_timestamp(#{end_date})")
+                  .group("date(created_at)")
+    dates = (Date.today-num_of_days..Date.today)
+    results = {}
+    dates.each { |date|
+      clicks.each { |click| results[date] = click.count if click.date == date }
+      results[date] = 0 unless results[date]
+    }
+    results.sort.reverse
+  end
+
+  def self.count_by_country_with(identifier)
+    Click.select("country, count(*) as count").where("link_id = #{identifier}")
+         .group("country")
+  end
 end

--- a/app/views/links/show.html.erb
+++ b/app/views/links/show.html.erb
@@ -1,14 +1,30 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Short url:</strong>
-  <a href = <%= "#{display_link(@link.short_url)}" %> target ="_blank"><%= display_link(@link.short_url)%></a>
-</p>
-
-<p>
   <strong>Url:</strong>
   <%= @link.url %>
 </p>
 
-<%= link_to 'Edit', edit_link_path(@link) %> |
-<%= link_to 'Back', links_path %>
+<p>
+  <strong>Short url:</strong>
+  <%= @link.short_url %>
+</p>
+
+<div class="panel panel-default center-block">
+  <div class="panel-heading">Number of visits by country</div>
+  <div class="panel-body">
+    <img src="<%= @count_country_map %>" class="img-responsive ">
+  </div>
+</div>
+
+<div class="panel panel-default center-block">
+  <div class="panel-heading">Number of visits</div>
+  <div class="panel-body">
+    <img src="<%= @count_country_bar %>" class="img-responsive ">
+  </div>
+</div>
+
+<div class="btm-space">
+  <%= link_to 'Edit', edit_link_path(@link) %> |
+  <%= link_to 'Back', dashboard_path %>
+</div>

--- a/db/migrate/20151217021309_add_attributes_to_click.rb
+++ b/db/migrate/20151217021309_add_attributes_to_click.rb
@@ -1,0 +1,6 @@
+class AddAttributesToClick < ActiveRecord::Migration
+  def change
+    add_column :clicks, :ip, :inet
+    add_column :clicks, :country, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151216163002) do
+ActiveRecord::Schema.define(version: 20151217021309) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 20151216163002) do
     t.integer  "link_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.inet     "ip"
+    t.string   "country"
   end
 
   add_index "clicks", ["link_id"], name: "index_clicks_on_link_id", using: :btree


### PR DESCRIPTION
Why: So registered users can view usage details about each URL

This change addresses the need by:
*Generating a migration to add ip address and country of users to the click table
*Modifying the LinksCotroller#redirect to capture the details of each click before redirect
*Defining methods in ClicksHelper to get the ip and country where click originated from.
*Defining methods in Click model class to set the ip and country of click and also setup charts for display in details view
*Modifying the Links show view to display the usage information.

[Finishes #110112658]
[Finishes #110112570]
