### PR TITLE
Shortened URL activeness

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,6 +1,6 @@
 class LinksController < ApplicationController
   include LinksHelper
-  include ClicksHelper  
+  include ClicksHelper
 
   before_action :set_link, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user, except: [:create, :redirect_link]
@@ -60,16 +60,18 @@ class LinksController < ApplicationController
   # PATCH/PUT /links/1
   # PATCH/PUT /links/1.json
   def update
-    respond_to do |format|
-      if @link.update(link_params)
-        format.html { redirect_to @link, notice: 'Link was successfully updated.' }
-        format.json { render :show, status: :ok, location: @link }
-      else
-        format.html { render :edit }
-        format.json { render json: @link.errors, status: :unprocessable_entity }
+      respond_to do |format|
+        if @link.update(link_params)
+          format.html do
+            redirect_to dashboard_path, notice: "Link was successfully updated."
+          end
+          format.json { render :show, status: :ok, location: @link }
+        else
+          format.html { render :edit }
+          format.json { render json: @link.errors, status: :unprocessable_entity }
+        end
       end
     end
-  end
 
   # DELETE /links/1
   # DELETE /links/1.json
@@ -83,11 +85,15 @@ class LinksController < ApplicationController
 
   def redirect_link
     @link = Link.find_by(short_url: params[:path])
-    click = @link.clicks.new(ip: get_remote_ip)
-    click.country = get_remote_country
-    click.save
-    @link.save
-    redirect_to @link.url
+    if @link.active
+      click = @link.clicks.new(ip: get_remote_ip)
+      click.country = get_remote_country
+      click.save
+      @link.save
+      redirect_to @link.url
+    else
+      redirect_to root_path, alert: "Link is curently inactive."
+    end
   end
 
   private
@@ -98,6 +104,6 @@ class LinksController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def link_params
-      params.require(:link).permit(:short_url, :url)
+      params.require(:link).permit(:short_url, :url, :active)
     end
 end

--- a/app/views/links/_form.html.erb
+++ b/app/views/links/_form.html.erb
@@ -1,10 +1,46 @@
-<%= semantic_form_for @link do |f| %>
-  <%= f.inputs do %>
-    <%= f.input :short_url %>
-    <%= f.input :url %>
-  <% end %>
+<div class="container">
+  <div class="row">
+    <%= form_for @link, html: { class: "form-horizontal" } do |f| %>
+      <% if @link.errors.any? %>
+        <div id="error_explanation">
+          <h2><%= pluralize(@link.errors.count, "error") %> prohibited this link from being saved:</h2>
 
-  <%= f.actions do %>
-    <%= f.action :submit, :as => :input %>
-  <% end %>
-<% end %>
+          <ul>
+          <% @link.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div class="field form-group">
+        <%= f.label :url, class: "col-sm-2 control-label" %><br>
+        <div class="col-sm-8">
+          <%= f.text_field :url, class: "form-control" %>
+        </div>
+      </div>
+      <div class="field form-group">
+        <%= f.label :short_url, class: "col-sm-2 control-label" %><br>
+        <div class="col-sm-8">
+          <%= f.text_field :short_url, class: "form-control" %>
+        </div>
+      </div>
+      <div class="form-group">
+        <%= f.label :active, class: "col-sm-2 control-label"  %>
+        <div class="col-sm-10">
+          <div class="checkbox">
+          <label>
+            <%= f.check_box :active %>
+          </label>
+          </div>
+        </div>
+      </div>
+      <div class="actions form-group">
+        <div class="col-sm-offset-2 col-sm-10">
+          <%= f.submit class: "btn btn-primary"%>
+        </div>
+      </div>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Editing Link</h1>
+<h1>Edit Link</h1>
 
 <%= render 'form' %>
 

--- a/db/migrate/20151217030551_add_index_to_link.rb
+++ b/db/migrate/20151217030551_add_index_to_link.rb
@@ -1,0 +1,5 @@
+class AddIndexToLink < ActiveRecord::Migration
+  def change
+    add_index :links, :short_url, unique: true
+  end
+end

--- a/db/migrate/20151217030754_add_attributes_to_link.rb
+++ b/db/migrate/20151217030754_add_attributes_to_link.rb
@@ -1,0 +1,5 @@
+class AddAttributesToLink < ActiveRecord::Migration
+  def change
+    add_column :links, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151217021309) do
+ActiveRecord::Schema.define(version: 20151217030754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,12 +29,14 @@ ActiveRecord::Schema.define(version: 20151217021309) do
   create_table "links", force: :cascade do |t|
     t.string   "short_url"
     t.string   "url"
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
     t.integer  "clicks_count", default: 0
     t.integer  "user_id"
+    t.boolean  "active",       default: true
   end
 
+  add_index "links", ["short_url"], name: "index_links_on_short_url", unique: true, using: :btree
   add_index "links", ["user_id"], name: "index_links_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Why: So registered users can set/reset the activeness of their shortened URLs

This change adresses the need by:
*Creating a migration to add active column to the Link model
*Modifying the LinksController#redirect_link to check for link activeness befor$
*Modifying the partial links/_form.html.erb to display the active field

[Finishes #110112954]
[Finishes #110112874]
