### PR TITLE
URL Management (deleted)

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -85,12 +85,14 @@ class LinksController < ApplicationController
 
   def redirect_link
     @link = Link.find_by(short_url: params[:path])
-    if @link.active
+    if @link.active && !@link.deleted
       click = @link.clicks.new(ip: get_remote_ip)
       click.country = get_remote_country
       click.save
       @link.save
       redirect_to @link.url
+    elsif @link.deleted
+      redirect_to root_path, alert: "Link has been deleted by owner."
     else
       redirect_to root_path, alert: "Link is curently inactive."
     end
@@ -104,6 +106,6 @@ class LinksController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def link_params
-      params.require(:link).permit(:short_url, :url, :active)
+      params.require(:link).permit(:short_url, :url, :active, :deleted)
     end
 end

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -1,6 +1,7 @@
 <%# Rails flash messages styled for Bootstrap 3.0 %>
+
 <% flash.each do |name, msg| %>
-  <% if msg.is_a?(String) %>
+  <% if msg.is_a?(String)  %>
     <div class="alert alert-<%= name.to_s == 'notice' ? 'success' : 'danger' %>">
       <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
       <%= content_tag :div, msg, :id => "flash_#{name}" %>

--- a/app/views/links/_form.html.erb
+++ b/app/views/links/_form.html.erb
@@ -35,6 +35,16 @@
           </div>
         </div>
       </div>
+      <div class="form-group">
+        <%= f.label :deleted, class: "col-sm-2 control-label"  %>
+        <div class="col-sm-10">
+          <div class="checkbox">
+          <label>
+            <%= f.check_box :deleted %>
+          </label>
+          </div>
+        </div>
+      </div>
       <div class="actions form-group">
         <div class="col-sm-offset-2 col-sm-10">
           <%= f.submit class: "btn btn-primary"%>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -42,9 +42,6 @@
             <td><%= link.url %></td>
             <td><%= link_to 'Details', link %></td>
             <td><%= link_to 'Edit', edit_link_path(link) %></td>
-            <td><%= link_to 'Destroy', link, method: :delete,
-                  data: { confirm: 'Are you sure?' } %>
-            </td>
           </tr>
         <% end %>
       </tbody>

--- a/db/migrate/20151217080618_add_deleted_to_link.rb
+++ b/db/migrate/20151217080618_add_deleted_to_link.rb
@@ -1,0 +1,5 @@
+class AddDeletedToLink < ActiveRecord::Migration
+  def change
+    add_column :links, :deleted, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151217030754) do
+ActiveRecord::Schema.define(version: 20151217080618) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20151217030754) do
     t.integer  "clicks_count", default: 0
     t.integer  "user_id"
     t.boolean  "active",       default: true
+    t.boolean  "deleted"
   end
 
   add_index "links", ["short_url"], name: "index_links_on_short_url", unique: true, using: :btree
@@ -52,7 +53,4 @@ ActiveRecord::Schema.define(version: 20151217030754) do
   add_index "users", ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true, using: :btree
   add_index "users", ["provider"], name: "index_users_on_provider", using: :btree
   add_index "users", ["uid"], name: "index_users_on_uid", using: :btree
-
-  add_foreign_key "clicks", "links"
-  add_foreign_key "links", "users"
 end


### PR DESCRIPTION
Why: So registered user can set service shortened url to deleted

This change addresses this need by:
*Creating a migration to add deleted column to Link model
*Modifying LinksController#redirect_link to check if link.deleted is true
*Adding :deleted to require params
*Modifying links/_form view to allow for editing deleted attribute

[Finishes #110112762]
